### PR TITLE
Fix translations on all pages and clean up scripts

### DIFF
--- a/certifications.js
+++ b/certifications.js
@@ -1,6 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
-    // Initialize AOS animation library
-    AOS.init();
+    // AOS is initialized in script.js
 
     // Get all filter buttons and certification cards
     const filterButtons = document.querySelectorAll('.filter-btn');
@@ -80,7 +79,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Trigger stat animation when stats section comes into view
     const statsSection = document.querySelector('.achievement-stats');
-    const statsAnimated = false;
+    let statsAnimated = false; // Changed const to let
 
     function checkStats() {
         if (statsSection && isInViewport(statsSection) && !statsAnimated) {
@@ -93,6 +92,5 @@ document.addEventListener('DOMContentLoaded', function() {
     window.addEventListener('scroll', checkStats);
     checkStats(); // Check on page load
 
-    // Set current year in footer
-    document.getElementById('current-year').textContent = new Date().getFullYear();
+    // Current year is set in script.js
 });

--- a/projects.html
+++ b/projects.html
@@ -318,11 +318,7 @@
 <script>
     // Initialize AOS animation library
     document.addEventListener('DOMContentLoaded', function() {
-        AOS.init({
-            duration: 800,
-            easing: 'ease-in-out',
-            once: true
-        });
+        // AOS is initialized in script.js
 
     // Simple search and filter functionality
         const filterBtns = document.querySelectorAll('.filter-btn');


### PR DESCRIPTION
- Fixed TypeError in `certifications.js` by changing `statsAnimated` from `const` to `let`. This was likely preventing translations and other JS from running correctly on the certifications page.
- Removed redundant AOS initializations from `certifications.js` and the inline script in `projects.html` (global `script.js` handles this).
- Removed redundant current year footer update from `certifications.js` (global `script.js` handles this).
- Verified that `translations.js` is correctly included and its `DOMContentLoaded` logic should now function reliably across all pages.

These changes address the issue where translations were reportedly only working on the index page.